### PR TITLE
Detect development version of age

### DIFF
--- a/age.el
+++ b/age.el
@@ -185,11 +185,12 @@ version requirement is met."
 (defun age-config--make-age-configuration (program)
   "Make an age configuration for PROGRAM."
   (let ((version
-         (let ((v (shell-command-to-string (format "%s --version" program))))
+         (pcase (shell-command-to-string (format "%s --version" program))
            ;; assuming https://semver.org/
-           (when (string-match "\\([0-9]+\\.[0-9]+\\.[0-9]+\\)" v)
-             (match-string 1 v)))))
-    (list (cons 'program program)
+           ((rx (let v (seq(+ digit) "." (+ digit) "." (+ digit)))) v)
+           ((rx "(devel)") "9.9.9")
+           (_ nil))))
+    (list (cons 'program "age")
           (cons 'version version))))
 
 ;;;###autoload

--- a/age.el
+++ b/age.el
@@ -187,10 +187,10 @@ version requirement is met."
   (let ((version
          (pcase (shell-command-to-string (format "%s --version" program))
            ;; assuming https://semver.org/
-           ((rx (let v (seq(+ digit) "." (+ digit) "." (+ digit)))) v)
+           ((rx (let v (seq (+ digit) "." (+ digit) "." (+ digit)))) v)
            ((rx "(devel)") "9.9.9")
            (_ nil))))
-    (list (cons 'program "age")
+    (list (cons 'program program)
           (cons 'version version))))
 
 ;;;###autoload


### PR DESCRIPTION
This version identifies itself with (devel), replace that with version 9.9.9.

The Termux package for age uses the development version. Age.el did not recognize the version string and therefore didn't load.