### PR TITLE
Fix custom variable check for use-package :custom blocks.

### DIFF
--- a/age.el
+++ b/age.el
@@ -169,8 +169,11 @@ version requirement is met."
         (or (and (not no-cache) (alist-get protocol age--configurations))
             ;; If the executable value is already set with M-x
             ;; customize, use it without checking.
-            (if (and symbol (or (get symbol 'saved-value)
-                                (get symbol 'customized-value)))
+            (if (and symbol (or
+                             ;; use-package :custom blocks end up as theme values
+                             (get symbol 'theme-value)
+                             (get symbol 'saved-value)
+                             (get symbol 'customized-value)))
                 (let ((configuration
                        (funcall constructor (symbol-value symbol))))
                   (push (cons protocol configuration) age--configurations)


### PR DESCRIPTION
Related to: https://github.com/jwiegley/use-package/issues/1002

Use-package :custom blocks end up as theme-value symbol properties. Since our code is forked from epg, we inherited its symbol property checks that don't account for use-package's theme-value property on :custom variables.

This can introduce cache confusion and result in the incorrect binary being invoked on systems that contain e.g. both rage and age binaries due to program alist ordering.

The user's custom value should always take precedent over any auto configuration.