### PR TITLE
Fix minor mode not enabled; remove unnecessary functions

### DIFF
--- a/age.el
+++ b/age.el
@@ -829,7 +829,7 @@ May either be a string or a list of strings.")
 ;;;###autoload
 (define-minor-mode age-encryption-mode
   "Toggle automatic Age file encryption/decryption (Age Encryption mode)."
-  :global t :init-value t :group 'age-file :version "0.1"
+  :global t :group 'age-file :version "0.1"
   ;;:initialize 'custom-initialize-delay
   (age-advise-tramp t)
   (setq file-name-handler-alist (delq age-file-handler file-name-handler-alist))

--- a/age.el
+++ b/age.el
@@ -1276,34 +1276,6 @@ function `write-region'."
                (age-make-context)
                "Select recipients for encryption.")))
 
-;;;###autoload
-(defun age-file-enable ()
-  "Enable age file handling."
-  (interactive)
-  (age-advise-tramp)
-  (if (memq age-file-handler file-name-handler-alist)
-      (message "`age-file' already enabled")
-    (setq file-name-handler-alist
-	  (cons age-file-handler file-name-handler-alist))
-    (add-hook 'find-file-hook #'age-file-find-file-hook)
-    (setq auto-mode-alist (cons age-file-auto-mode-alist-entry auto-mode-alist))
-    (message "`age-file' enabled")))
-
-;;;###autoload
-(defun age-file-disable ()
-  "Disable age file handling."
-  (interactive)
-  (age-advise-tramp t)
-  (if (memq age-file-handler file-name-handler-alist)
-      (progn
-	(setq file-name-handler-alist
-	      (delq age-file-handler file-name-handler-alist))
-	(remove-hook 'find-file-hook #'age-file-find-file-hook)
-	(setq auto-mode-alist (delq age-file-auto-mode-alist-entry
-				    auto-mode-alist))
-	(message "`age-file' disabled"))
-    (message "`age-file' already disabled")))
-
 (provide 'age)
 
 ;;; age.el ends here


### PR DESCRIPTION
Hello!

Thank you for all your work on this, it's so freeing to not need to use GPG!

I ran into a problem where global minor mode `age-encryption-mode` was not enabled, despite the variable `age-encryption-mode` being non-nil. This seemed weird, but I found the issue: `:init-value t`. This sets the variable to `t` but doesn't actually call the function, thus not adding the file handler or auto-mode. Also, from the Elisp manual:

> :init-value INIT-VALUE
>
> This is the value to which the MODE variable is initialized.
> Except in unusual circumstances (see below), this value must
> be ‘nil’.

As you can see, it's the mode *variable* not the actual minor mode itself. Then further down:

> The initial value must be ‘nil’ except in cases where (1) the mode is
> preloaded in Emacs, or (2) it is painless for loading to enable the mode
> even though the user did not request it.  For instance, if the mode has
> no effect unless something else is enabled, and will always be loaded by
> that time, enabling it by default is harmless.  But these are unusual
> circumstances.  Normally, the initial value must be ‘nil’.

Not completely clear what "painless" means, but I think age doesn't fall into that camp.

The other change I made is removing the functions `age-file-enable` and `age-file-disable`. These just duplicate the functionality of toggling `age-encryption-mode`.

Let me know if you'd prefer I split this into two PRs.

Thanks again.